### PR TITLE
Add support for batch read operations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
         <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
 
-        <aerospike-client.version>5.0.7</aerospike-client.version>
+        <aerospike-client.version>5.1.8</aerospike-client.version>
         <netty.version>4.1.63.Final</netty.version>
         <commons-cli.version>1.2</commons-cli.version>
         <junit.version>4.13.1</junit.version>

--- a/reactor-client/src/main/java/com/aerospike/client/reactor/AerospikeReactorClient.java
+++ b/reactor-client/src/main/java/com/aerospike/client/reactor/AerospikeReactorClient.java
@@ -128,6 +128,17 @@ public class AerospikeReactorClient implements IAerospikeReactorClient{
 	}
 
 	@Override
+	public final Mono<KeysRecords> get(Key[] keys, Operation... operations) throws AerospikeException {
+		return get(null, keys, operations);
+	}
+
+	@Override
+	public final Mono<KeysRecords> get(BatchPolicy policy, Key[] keys, Operation... operations) throws AerospikeException {
+		return Mono.create(sink -> aerospikeClient.get(
+				null, new ReactorRecordArrayListener(sink), policy, keys, operations));
+	}
+
+	@Override
 	public final Flux<BatchRead> getFlux(List<BatchRead> records) throws AerospikeException {
 		return getFlux(null, records);
 	}
@@ -147,6 +158,17 @@ public class AerospikeReactorClient implements IAerospikeReactorClient{
 	public final Flux<KeyRecord> getFlux(BatchPolicy policy, Key[] keys) throws AerospikeException {
 		return Flux.create(sink -> aerospikeClient.get(
 				null, new ReactorRecordSequenceListener(sink), policy, keys));
+	}
+
+	@Override
+	public final Flux<KeyRecord> getFlux(Key[] keys, Operation... operations) throws AerospikeException {
+		return getFlux(null, keys, operations);
+	}
+
+	@Override
+	public final Flux<KeyRecord> getFlux(BatchPolicy policy, Key[] keys, Operation... operations) throws AerospikeException {
+		return Flux.create(sink -> aerospikeClient.get(
+				null, new ReactorRecordSequenceListener(sink), policy, keys, operations));
 	}
 
 	@Override

--- a/reactor-client/src/main/java/com/aerospike/client/reactor/IAerospikeReactorClient.java
+++ b/reactor-client/src/main/java/com/aerospike/client/reactor/IAerospikeReactorClient.java
@@ -139,6 +139,39 @@ public interface IAerospikeReactorClient extends DefaultPolicyProvider, Closeabl
 	Mono<List<BatchRead>> get(BatchPolicy policy, List<BatchRead> records) throws AerospikeException;
 
 	/**
+	 * Reactively read multiple records for specified keys using read operations in one batch call.
+	 * This method registers the command with an event loop and returns.
+	 * The event loop thread will process the command and send the results to the listener.
+	 * <p>
+	 * The returned records are in positional order with the original key array order.
+	 * If a key is not found, the positional record will be null.
+	 * <p>
+	 * If a batch request to a node fails, the entire batch is cancelled.
+	 *
+	 * @param keys					array of unique record identifiers
+	 * @param operations			array of read operations on record
+	 * @throws AerospikeException	if event loop registration fails
+	 */
+	Mono<KeysRecords> get(Key[] keys, Operation... operations) throws AerospikeException;
+
+	/**
+	 * Reactively read multiple records for specified keys using read operations in one batch call.
+	 * This method registers the command with an event loop and returns.
+	 * The event loop thread will process the command and send the results to the listener.
+	 * <p>
+	 * The returned records are in positional order with the original key array order.
+	 * If a key is not found, the positional record will be null.
+	 * <p>
+	 * If a batch request to a node fails, the entire batch is cancelled.
+	 *
+	 * @param policy				batch configuration parameters, pass in null for defaults
+	 * @param keys					array of unique record identifiers
+	 * @param operations			array of read operations on record
+	 * @throws AerospikeException	if event loop registration fails
+	 */
+	Mono<KeysRecords> get(BatchPolicy policy, Key[] keys, Operation... operations) throws AerospikeException;
+
+	/**
 	 * Reactively read multiple records for specified batch keys in one batch call.
 	 * This method registers the command with an event loop and returns.
 	 * The event loop thread will process the command and send the results to the listener.
@@ -198,6 +231,41 @@ public interface IAerospikeReactorClient extends DefaultPolicyProvider, Closeabl
 	 * @throws AerospikeException	if event loop registration fails
 	 */
 	Flux<KeyRecord> getFlux(BatchPolicy policy, Key[] keys) throws AerospikeException;
+
+	/**
+	 * Reactively read multiple records for specified keys using read operations in one batch call.
+	 * This method registers the command with an event loop and returns.
+	 * The event loop thread will process the command and send the results to the listener.
+	 * <p>
+	 * Each record result is returned in separate onRecord() calls.
+	 * If a key is not found, the record will be null.
+	 * <p>
+	 * If a batch request to a node fails, responses from other nodes will continue to
+	 * be processed.
+	 *
+	 * @param keys					array of unique record identifiers
+	 * @param operations			array of read operations on record
+	 * @throws AerospikeException	if event loop registration fails
+	 */
+	Flux<KeyRecord> getFlux(Key[] keys, Operation... operations) throws AerospikeException;
+
+	/**
+	 * Reactively read multiple records for specified keys using read operations in one batch call.
+	 * This method registers the command with an event loop and returns.
+	 * The event loop thread will process the command and send the results to the listener.
+	 * <p>
+	 * Each record result is returned in separate onRecord() calls.
+	 * If a key is not found, the record will be null.
+	 * <p>
+	 * If a batch request to a node fails, responses from other nodes will continue to
+	 * be processed.
+	 *
+	 * @param policy				batch configuration parameters, pass in null for defaults
+	 * @param keys					array of unique record identifiers
+	 * @param operations			array of read operations on record
+	 * @throws AerospikeException	if event loop registration fails
+	 */
+	Flux<KeyRecord> getFlux(BatchPolicy policy, Key[] keys, Operation... operations) throws AerospikeException;
 
 	/**
 	 * Reactively read record generation and expiration only for specified key.  Bins are not read.

--- a/reactor-client/src/main/java/com/aerospike/client/reactor/retry/AerospikeReactorRetryClient.java
+++ b/reactor-client/src/main/java/com/aerospike/client/reactor/retry/AerospikeReactorRetryClient.java
@@ -88,6 +88,16 @@ public class AerospikeReactorRetryClient implements IAerospikeReactorClient {
 	}
 
 	@Override
+	public Mono<KeysRecords> get(Key[] keys, Operation... operations) throws AerospikeException {
+		return get(null, keys, operations);
+	}
+
+	@Override
+	public Mono<KeysRecords> get(BatchPolicy policy, Key[] keys, Operation... operations) throws AerospikeException {
+		return client.get(policy, keys, operations).retryWhen(retryPolicy);
+	}
+
+	@Override
 	public final Flux<BatchRead> getFlux(List<BatchRead> records) throws AerospikeException {
 		return getFlux(null, records);
 	}
@@ -105,6 +115,16 @@ public class AerospikeReactorRetryClient implements IAerospikeReactorClient {
 	@Override
 	public final Flux<KeyRecord> getFlux(BatchPolicy policy, Key[] keys) throws AerospikeException {
 		return client.getFlux(policy, keys).retryWhen(retryPolicy);
+	}
+
+	@Override
+	public Flux<KeyRecord> getFlux(Key[] keys, Operation... operations) throws AerospikeException {
+		return getFlux(null, keys, operations);
+	}
+
+	@Override
+	public Flux<KeyRecord> getFlux(BatchPolicy policy, Key[] keys, Operation... operations) throws AerospikeException {
+		return client.getFlux(policy, keys, operations).retryWhen(retryPolicy);
 	}
 
 	@Override

--- a/reactor-client/src/test/java/com/aerospike/client/reactor/BatchReactorTest.java
+++ b/reactor-client/src/test/java/com/aerospike/client/reactor/BatchReactorTest.java
@@ -20,6 +20,10 @@ import com.aerospike.client.*;
 import com.aerospike.client.Record;
 import com.aerospike.client.cdt.ListOperation;
 import com.aerospike.client.cdt.ListReturnType;
+import com.aerospike.client.exp.Exp;
+import com.aerospike.client.exp.ExpOperation;
+import com.aerospike.client.exp.ExpReadFlags;
+import com.aerospike.client.exp.Expression;
 import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.query.KeyRecord;
 import com.aerospike.client.reactor.dto.KeyExists;
@@ -76,10 +80,10 @@ public class BatchReactorTest extends ReactorTest {
 
 							Bin listBin = new Bin(LIST_BIN, list);
 
-							if (i != 6) {
+							if ((i + 1) != 6) {
 								return reactorClient.put(policy, key, bin, listBin);
 							} else {
-								return reactorClient.put(policy, key, new Bin(binName, i + 1), listBin);
+								return reactorClient.put(policy, key, new Bin(binName, (i + 1)), listBin);
 							}
 						}).collect(Collectors.toList()),
 				objects -> objects).block();
@@ -148,7 +152,7 @@ public class BatchReactorTest extends ReactorTest {
 		StepVerifier.create(mono)
 				.expectNextMatches(keysRecords -> {
 					for (int i = 0; i < keysRecords.records.length; i++) {
-						if (i != 6) {
+						if (i != 5) {
 							assertBinEqual(keysRecords.keys[i], keysRecords.records[i], binName, VALUE_PREFIX + (i + 1));
 						} else {
 							assertBinEqual(keysRecords.keys[i], keysRecords.records[i], binName, i + 1L);
@@ -213,8 +217,8 @@ public class BatchReactorTest extends ReactorTest {
 		// Batch allows multiple namespaces in one call, but example test environment may only have one namespace.
 
 		// bin * 8
-		//Expression exp = Exp.build(Exp.mul(Exp.intBin(BIN_NAME), Exp.val(8)));
-		//Operation[] ops = Operation.array(ExpOperation.read(BIN_NAME, exp, ExpReadFlags.DEFAULT));
+		//Expression exp = Exp.build(Exp.mul(Exp.intBin(binName), Exp.val(8)));
+		//Operation[] ops = Operation.array(ExpOperation.read(binName, exp, ExpReadFlags.DEFAULT));
 
 		String[] bins = new String[] {binName};
 		List<BatchRead> records = new ArrayList<>();
@@ -249,8 +253,8 @@ public class BatchReactorTest extends ReactorTest {
 									//readAllBeans == false
 									null,
 									"batchvalue5",
-									"batchvalue6",
-									7L,
+									6L,
+									"batchvalue7",
 									//no bean with name "binnotfound"
 									null);
 

--- a/reactor-client/src/test/java/com/aerospike/client/reactor/BatchReactorTest.java
+++ b/reactor-client/src/test/java/com/aerospike/client/reactor/BatchReactorTest.java
@@ -217,8 +217,8 @@ public class BatchReactorTest extends ReactorTest {
 		// Batch allows multiple namespaces in one call, but example test environment may only have one namespace.
 
 		// bin * 8
-		//Expression exp = Exp.build(Exp.mul(Exp.intBin(binName), Exp.val(8)));
-		//Operation[] ops = Operation.array(ExpOperation.read(binName, exp, ExpReadFlags.DEFAULT));
+		Expression exp = Exp.build(Exp.mul(Exp.intBin(binName), Exp.val(8)));
+		Operation[] ops = Operation.array(ExpOperation.read(binName, exp, ExpReadFlags.DEFAULT));
 
 		String[] bins = new String[] {binName};
 		List<BatchRead> records = new ArrayList<>();
@@ -227,7 +227,7 @@ public class BatchReactorTest extends ReactorTest {
 		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 3), true));
 		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 4), false));
 		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 5), true));
-		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 6), true));
+		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 6), ops));
 		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 7), bins));
 
 		// This record should be found, but the requested bin will not be found.
@@ -238,7 +238,6 @@ public class BatchReactorTest extends ReactorTest {
 
 		// Execute batch.
 		Mono<List<BatchRead>> mono = reactorClient.get(records);
-
 		StepVerifier.create(mono)
 				.expectNextMatches(batchReads -> {
 					List<BatchRead> recordsFound = batchReads.stream()
@@ -253,7 +252,7 @@ public class BatchReactorTest extends ReactorTest {
 									//readAllBeans == false
 									null,
 									"batchvalue5",
-									6L,
+									48L,
 									"batchvalue7",
 									//no bean with name "binnotfound"
 									null);

--- a/reactor-client/src/test/java/com/aerospike/client/reactor/BatchReactorTest.java
+++ b/reactor-client/src/test/java/com/aerospike/client/reactor/BatchReactorTest.java
@@ -16,10 +16,14 @@
  */
 package com.aerospike.client.reactor;
 
-import com.aerospike.client.BatchRead;
-import com.aerospike.client.Bin;
-import com.aerospike.client.Key;
+import com.aerospike.client.*;
 import com.aerospike.client.Record;
+import com.aerospike.client.cdt.ListOperation;
+import com.aerospike.client.cdt.ListReturnType;
+import com.aerospike.client.exp.Exp;
+import com.aerospike.client.exp.ExpOperation;
+import com.aerospike.client.exp.ExpReadFlags;
+import com.aerospike.client.exp.Expression;
 import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.query.KeyRecord;
 import com.aerospike.client.reactor.dto.KeyExists;
@@ -33,17 +37,20 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BatchReactorTest extends ReactorTest {
-	private static final String keyPrefix = "batchkey";
-	private static final String valuePrefix = "batchvalue";
-	private final String binName = args.getBinName("batchbin");
-	private static final int size = 8;
+	private static final String LIST_BIN = "listbin";
+	private static final String KEY_PREFIX = "batchkey";
+	private static final String VALUE_PREFIX = "batchvalue";
+	private final String BIN_NAME = args.getBinName("batchbin");
+	private static final int SIZE = 8;
 	private Key[] sendKeys;
 	private Key[] notSendKeys;
 
@@ -53,24 +60,37 @@ public class BatchReactorTest extends ReactorTest {
 
 	@Before
 	public void fillData() {
-		sendKeys = new Key[size];
+		sendKeys = new Key[SIZE];
 
 		WritePolicy policy = new WritePolicy();
 		policy.expiration = 2592000;
 
 		Mono.zip(
-				IntStream.range(0, size)
+				IntStream.range(0, SIZE)
 						.mapToObj(i -> {
-							final Key key = new Key(args.namespace, args.set, keyPrefix + (i + 1));
+							final Key key = new Key(args.namespace, args.set, KEY_PREFIX + (i + 1));
 							sendKeys[i] = key;
-							Bin bin = new Bin(binName, valuePrefix + (i + 1));
-							return reactorClient.put(policy, key, bin);
+							Bin bin = new Bin(BIN_NAME, VALUE_PREFIX + (i + 1));
+
+							List<Integer> list = new ArrayList<>();
+
+							for (int j = 0; j < (i + 1); j++) {
+								list.add(j * (i + 1));
+							}
+
+							Bin listBin = new Bin(LIST_BIN, list);
+
+							if (i != 6) {
+								return reactorClient.put(policy, key, bin, listBin);
+							} else {
+								return reactorClient.put(policy, key, new Bin(BIN_NAME, i + 1), listBin);
+							}
 						}).collect(Collectors.toList()),
 				objects -> objects).block();
 
 		notSendKeys = new Key[]{
-				new Key(args.namespace, args.set, keyPrefix+"absent1"),
-				new Key(args.namespace, args.set, keyPrefix+"absent2")
+				new Key(args.namespace, args.set, KEY_PREFIX +"absent1"),
+				new Key(args.namespace, args.set, KEY_PREFIX +"absent2")
 		};
 	}
 
@@ -132,7 +152,11 @@ public class BatchReactorTest extends ReactorTest {
 		StepVerifier.create(mono)
 				.expectNextMatches(keysRecords -> {
 					for (int i = 0; i < keysRecords.records.length; i++) {
-						assertBinEqual(keysRecords.keys[i], keysRecords.records[i], binName, valuePrefix + (i + 1));
+						if (i != 6) {
+							assertBinEqual(keysRecords.keys[i], keysRecords.records[i], BIN_NAME, VALUE_PREFIX + (i + 1));
+						} else {
+							assertBinEqual(keysRecords.keys[i], keysRecords.records[i], BIN_NAME, i + 1L);
+						}
 					}
 					return true;
 				})
@@ -149,7 +173,7 @@ public class BatchReactorTest extends ReactorTest {
 				.consumeRecordedWith(results -> assertThat(results)
 						.extracting(keyRecord -> {
 							assertRecordFound(keyRecord.key, keyRecord.record);
-							assertThat(keyRecord.record.getValue(binName)).isNotNull();
+							assertThat(keyRecord.record.getValue(BIN_NAME)).isNotNull();
 							return true;
 						})
 						.containsOnly(true))
@@ -175,7 +199,7 @@ public class BatchReactorTest extends ReactorTest {
 
 		StepVerifier.create(mono)
 				.expectNextMatches(keysRecords -> {
-					assertThat(keysRecords.records).hasSize(size);
+					assertThat(keysRecords.records).hasSize(SIZE);
 					for (int i = 0; i < keysRecords.records.length; i++) {
 						Record record = keysRecords.records[i];
 						assertRecordFound(keysRecords.keys[i], record);
@@ -191,18 +215,23 @@ public class BatchReactorTest extends ReactorTest {
 	public void batchReadComplex() {
 		// Batch gets into one call.
 		// Batch allows multiple namespaces in one call, but example test environment may only have one namespace.
-		String[] bins = new String[] {binName};
-		List<BatchRead> records = new ArrayList<BatchRead>();
-		records.add(new BatchRead(new Key(args.namespace, args.set, keyPrefix + 1), bins));
-		records.add(new BatchRead(new Key(args.namespace, args.set, keyPrefix + 2), true));
-		records.add(new BatchRead(new Key(args.namespace, args.set, keyPrefix + 3), true));
-		records.add(new BatchRead(new Key(args.namespace, args.set, keyPrefix + 4), false));
-		records.add(new BatchRead(new Key(args.namespace, args.set, keyPrefix + 5), true));
-		records.add(new BatchRead(new Key(args.namespace, args.set, keyPrefix + 6), true));
-		records.add(new BatchRead(new Key(args.namespace, args.set, keyPrefix + 7), bins));
+
+		// bin * 8
+		//Expression exp = Exp.build(Exp.mul(Exp.intBin(BIN_NAME), Exp.val(8)));
+		//Operation[] ops = Operation.array(ExpOperation.read(BIN_NAME, exp, ExpReadFlags.DEFAULT));
+
+		String[] bins = new String[] {BIN_NAME};
+		List<BatchRead> records = new ArrayList<>();
+		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 1), bins));
+		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 2), true));
+		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 3), true));
+		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 4), false));
+		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 5), true));
+		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 6), true));
+		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 7), bins));
 
 		// This record should be found, but the requested bin will not be found.
-		records.add(new BatchRead(new Key(args.namespace, args.set, keyPrefix + 8), new String[] {"binnotfound"}));
+		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 8), new String[] {"binnotfound"}));
 
 		// This record should not be found.
 		records.add(new BatchRead(new Key(args.namespace, args.set, "keynotfound"), bins));
@@ -216,7 +245,7 @@ public class BatchReactorTest extends ReactorTest {
 							.filter(record -> record.record != null)
 							.collect(Collectors.toList());
 					assertThat(recordsFound).hasSize(8);
-					assertThat(recordsFound).extracting(record -> record.record.getValue(binName))
+					assertThat(recordsFound).extracting(record -> record.record.getValue(BIN_NAME))
 							.containsExactly(
 									"batchvalue1",
 									"batchvalue2",
@@ -225,13 +254,38 @@ public class BatchReactorTest extends ReactorTest {
 									null,
 									"batchvalue5",
 									"batchvalue6",
-									"batchvalue7",
+									7L,
 									//no bean with name "binnotfound"
 									null);
 
 					return true;
 				})
 				.verifyComplete();
+	}
 
+	@Test
+	public void asyncBatchListOperate() {
+		Mono<KeysRecords> mono = reactorClient.get(sendKeys, ListOperation.size(LIST_BIN), ListOperation.getByIndex(LIST_BIN, -1, ListReturnType.VALUE));
+
+		StepVerifier.create(mono)
+				.expectNextMatches(keysRecords -> {
+					List<Record> recordsFound = Arrays.stream(keysRecords.records)
+							.filter(Objects::nonNull)
+							.collect(Collectors.toList());
+					assertThat(recordsFound).hasSize(8);
+					assertThat(recordsFound).extracting(record -> record.getValue(LIST_BIN).toString())
+							.containsExactly(
+									"[1, 0]",
+									"[2, 2]",
+									"[3, 6]",
+									"[4, 12]",
+									"[5, 20]",
+									"[6, 30]",
+									"[7, 42]",
+									"[8, 56]");
+
+					return true;
+				})
+				.verifyComplete();
 	}
 }

--- a/reactor-client/src/test/java/com/aerospike/client/reactor/BatchReactorTest.java
+++ b/reactor-client/src/test/java/com/aerospike/client/reactor/BatchReactorTest.java
@@ -20,10 +20,6 @@ import com.aerospike.client.*;
 import com.aerospike.client.Record;
 import com.aerospike.client.cdt.ListOperation;
 import com.aerospike.client.cdt.ListReturnType;
-import com.aerospike.client.exp.Exp;
-import com.aerospike.client.exp.ExpOperation;
-import com.aerospike.client.exp.ExpReadFlags;
-import com.aerospike.client.exp.Expression;
 import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.query.KeyRecord;
 import com.aerospike.client.reactor.dto.KeyExists;
@@ -49,7 +45,7 @@ public class BatchReactorTest extends ReactorTest {
 	private static final String LIST_BIN = "listbin";
 	private static final String KEY_PREFIX = "batchkey";
 	private static final String VALUE_PREFIX = "batchvalue";
-	private final String BIN_NAME = args.getBinName("batchbin");
+	private final String binName = args.getBinName("batchbin");
 	private static final int SIZE = 8;
 	private Key[] sendKeys;
 	private Key[] notSendKeys;
@@ -70,7 +66,7 @@ public class BatchReactorTest extends ReactorTest {
 						.mapToObj(i -> {
 							final Key key = new Key(args.namespace, args.set, KEY_PREFIX + (i + 1));
 							sendKeys[i] = key;
-							Bin bin = new Bin(BIN_NAME, VALUE_PREFIX + (i + 1));
+							Bin bin = new Bin(binName, VALUE_PREFIX + (i + 1));
 
 							List<Integer> list = new ArrayList<>();
 
@@ -83,7 +79,7 @@ public class BatchReactorTest extends ReactorTest {
 							if (i != 6) {
 								return reactorClient.put(policy, key, bin, listBin);
 							} else {
-								return reactorClient.put(policy, key, new Bin(BIN_NAME, i + 1), listBin);
+								return reactorClient.put(policy, key, new Bin(binName, i + 1), listBin);
 							}
 						}).collect(Collectors.toList()),
 				objects -> objects).block();
@@ -153,9 +149,9 @@ public class BatchReactorTest extends ReactorTest {
 				.expectNextMatches(keysRecords -> {
 					for (int i = 0; i < keysRecords.records.length; i++) {
 						if (i != 6) {
-							assertBinEqual(keysRecords.keys[i], keysRecords.records[i], BIN_NAME, VALUE_PREFIX + (i + 1));
+							assertBinEqual(keysRecords.keys[i], keysRecords.records[i], binName, VALUE_PREFIX + (i + 1));
 						} else {
-							assertBinEqual(keysRecords.keys[i], keysRecords.records[i], BIN_NAME, i + 1L);
+							assertBinEqual(keysRecords.keys[i], keysRecords.records[i], binName, i + 1L);
 						}
 					}
 					return true;
@@ -173,7 +169,7 @@ public class BatchReactorTest extends ReactorTest {
 				.consumeRecordedWith(results -> assertThat(results)
 						.extracting(keyRecord -> {
 							assertRecordFound(keyRecord.key, keyRecord.record);
-							assertThat(keyRecord.record.getValue(BIN_NAME)).isNotNull();
+							assertThat(keyRecord.record.getValue(binName)).isNotNull();
 							return true;
 						})
 						.containsOnly(true))
@@ -220,7 +216,7 @@ public class BatchReactorTest extends ReactorTest {
 		//Expression exp = Exp.build(Exp.mul(Exp.intBin(BIN_NAME), Exp.val(8)));
 		//Operation[] ops = Operation.array(ExpOperation.read(BIN_NAME, exp, ExpReadFlags.DEFAULT));
 
-		String[] bins = new String[] {BIN_NAME};
+		String[] bins = new String[] {binName};
 		List<BatchRead> records = new ArrayList<>();
 		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 1), bins));
 		records.add(new BatchRead(new Key(args.namespace, args.set, KEY_PREFIX + 2), true));
@@ -245,7 +241,7 @@ public class BatchReactorTest extends ReactorTest {
 							.filter(record -> record.record != null)
 							.collect(Collectors.toList());
 					assertThat(recordsFound).hasSize(8);
-					assertThat(recordsFound).extracting(record -> record.record.getValue(BIN_NAME))
+					assertThat(recordsFound).extracting(record -> record.record.getValue(binName))
 							.containsExactly(
 									"batchvalue1",
 									"batchvalue2",
@@ -264,7 +260,7 @@ public class BatchReactorTest extends ReactorTest {
 	}
 
 	@Test
-	public void asyncBatchListOperate() {
+	public void batchListOperate() {
 		Mono<KeysRecords> mono = reactorClient.get(sendKeys, ListOperation.size(LIST_BIN), ListOperation.getByIndex(LIST_BIN, -1, ListReturnType.VALUE));
 
 		StepVerifier.create(mono)

--- a/reactor-client/src/test/java/com/aerospike/client/reactor/ReactorIndexTest.java
+++ b/reactor-client/src/test/java/com/aerospike/client/reactor/ReactorIndexTest.java
@@ -69,7 +69,7 @@ public class ReactorIndexTest extends ReactorTest{
 
         StepVerifier.create(created)
                 .expectErrorMatches(throwable -> throwable instanceof AerospikeException
-                        && throwable.getMessage().equals("Error 201: Drop index failed: FAIL:201: Index does not exist on the system."))
+                        && throwable.getMessage().equals("Error 201: Drop index failed: FAIL:201: Index does not exist."))
                 .verify();
     }
 


### PR DESCRIPTION
The Java client version 5.1.6 added the ability to do an operate against multiple keys. Add support for this feature in the Reactive Java client.

Bump aerospike-client from 5.0.7 to 5.1.8.