### PR TITLE
Set version to 5.1.8 and Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>aerospike-client-java-reactive</name>
     <description>aerospike-client-java-reactive</description>
     <url>https://github.com/aerospike/aerospike-client-java-reactive</url>
-    <version>5.0.7</version>
+    <version>5.1.0</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -22,18 +22,18 @@
 
         <java.version>1.8</java.version>
 
-        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
-        <maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
-        <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
-        <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
-        <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+        <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
 
         <aerospike-client.version>5.1.8</aerospike-client.version>
-        <netty.version>4.1.63.Final</netty.version>
-        <commons-cli.version>1.2</commons-cli.version>
-        <junit.version>4.13.1</junit.version>
-        <slf4j-api.version>[1.7.25,)</slf4j-api.version>
+        <netty.version>4.1.68.Final</netty.version>
+        <commons-cli.version>1.4</commons-cli.version>
+        <junit.version>4.13.2</junit.version>
+        <slf4j-api.version>[1.7.32,)</slf4j-api.version>
     </properties>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>aerospike-client-java-reactive</name>
     <description>aerospike-client-java-reactive</description>
     <url>https://github.com/aerospike/aerospike-client-java-reactive</url>
-    <version>5.1.0</version>
+    <version>5.1.8</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/reactor-client/pom.xml
+++ b/reactor-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.aerospike</groupId>
         <artifactId>aerospike-client-java-reactive</artifactId>
-        <version>5.1.0</version>
+        <version>5.1.8</version>
     </parent>
     <artifactId>aerospike-reactor-client</artifactId>
     <packaging>jar</packaging>

--- a/reactor-client/pom.xml
+++ b/reactor-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.aerospike</groupId>
         <artifactId>aerospike-client-java-reactive</artifactId>
-        <version>5.0.7</version>
+        <version>5.1.0</version>
     </parent>
     <artifactId>aerospike-reactor-client</artifactId>
     <packaging>jar</packaging>
@@ -19,12 +19,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <reactor.version>3.4.4</reactor.version>
-        <assertj.version>3.19.0</assertj.version>
+        <reactor.version>3.4.10</reactor.version>
+        <assertj.version>3.21.0</assertj.version>
         <netcrusher.version>0.10</netcrusher.version>
 
         <skipTests>false</skipTests>
-        <mockito.version>3.9.0</mockito.version>
+        <mockito.version>3.12.4</mockito.version>
     </properties>
 
     <dependencies>
@@ -111,7 +111,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <doclint>none</doclint>
                     <reportOutputDirectory>${basedir}</reportOutputDirectory>
                     <doctitle>Aerospike Reactor Java Client</doctitle>
                     <show>public</show>


### PR DESCRIPTION
1. Set version to 5.1.0.
2. Bump dependencies:
maven-compiler-plugin from 3.8.0 to 3.8.1.
maven-surefire-plugin from 2.18.1 to 3.0.0-M5.
maven-javadoc-plugin from 2.9.1 to 3.3.1.
nexus-staging-maven-plugin from 1.6.7 to 1.6.8.
maven-source-plugin from 2.2.1 to 3.2.1.
maven-gpg-plugin from 1.5 to 1.6.
netty from 4.1.63.Final to 4.1.68.Final.
commons-cli from 1.2 to 1.4.
junit from 4.13.1 to 4.13.2.
slf4j-api from 1.7.25 to 1.7.32.
reactor-core from 3.4.4 to 3.4.10.
assertj from 3.19.0 to 3.21.0.
mockito from 3.9.0 to 3.12.4.